### PR TITLE
Tidy readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Then, define subfunctions whose name start with `test_` or end with `_test`. The
 
 As a special case, `moxunit_throw_test_skipped_exception('reason')` throws an exception that is caught when running the test; `moxunit_run_tests` will report that the test is skipped for reason `reason`.
 
-For example, the following function defines three unit tests that tests some possible inputs from the builtin `abs` function::
+For example, the following function defines three unit tests that tests some possible inputs from the builtin `abs` function:
 ```matlab
 function test_suite=my_test_of_abs
     initTestSuite

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 
 - Using the shell (requires a Unix-like operating system such as GNU/Linux or Apple OSX):
 
-    ```
+    ```bash
     git clone https://github.com/MOxUnit/MOxUnit.git
     cd MOxUnit
     make install
@@ -28,7 +28,7 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
     + Start Matlab or GNU Octave.
     + On the Matlab or GNU Octave prompt, `cd` to the `MOxUnit` root directory, then run:
     
-        ```
+        ```bash
         cd MOxUnit      % cd to MOxUnit subdirectory
         addpath(pwd())  % add the current directory to the Matlab/GNU Octave path
         savepath        % save the path
@@ -68,7 +68,7 @@ MOxUnit uses the [Travis-ci] service for continuous integration testing. This is
 ### Defining MOxUnit tests
 
 To define unit tests, write a function with the following header:
-```
+```matlab
 function test_suite=my_test_of_abs
     initTestSuite;
 ```
@@ -86,7 +86,7 @@ Then, define subfunctions whose name start with `test_` or end with `_test`. The
 As a special case, `moxunit_throw_test_skipped_exception('reason')` throws an exception that is caught when running the test; `moxunit_run_tests` will report that the test is skipped for reason `reason`.
 
 For example, the following function defines three unit tests that tests some possible inputs from the builtin `abs` function::
-```
+```matlab
 function test_suite=my_test_of_abs
     initTestSuite
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [GNU Octave]: http://www.gnu.org/software/octave/
 [Matlab]: http://www.mathworks.com/products/matlab/
 [Matlab xUnit test framework]: http://it.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework
-[MOxUnit]: github.com/MOxUnit/MOxUnit
+[MOxUnit]: https://github.com/MOxUnit/MOxUnit
 [Python unit test]: https://docs.python.org/2.6/library/unittest.html
 [Travis-ci]: https://travis-ci.org
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 
     + Download the zip archive from the [MOxUnit] website.
     + Start Matlab or GNU Octave.
-    + On the Matlab or GNU Octave prompt, ```cd``` to the ``MOxUnit`` root directory, then run:
+    + On the Matlab or GNU Octave prompt, `cd` to the `MOxUnit` root directory, then run:
     
         ```
         cd MOxUnit      % cd to MOxUnit subdirectory
@@ -36,8 +36,8 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 
 ### Running MOxUnit tests
 
-- ```cd``` to the directory where the unit tests reside. For MOxUnit itself, the unit tests are in the directory ```tests```.
-- run the tests using ```moxunit_runtests```. For example, running ```moxunit_runtests``` from MOxUnit's ```tests``` directory should give the following output:
+- `cd` to the directory where the unit tests reside. For MOxUnit itself, the unit tests are in the directory `tests`.
+- run the tests using `moxunit_runtests`. For example, running `moxunit_runtests` from MOxUnit's `tests` directory should give the following output:
   ```
   moxunit_runtests
   suite: 13 tests
@@ -51,11 +51,11 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 
        1
   ```
-- ```moxunit_runtests```, by default, gives non-verbose output and runs all tests in the current directory. This can be changed using the following arguments:
-  - ```-verbose```: show verbose output.
-  - ```directory```: run unit tests in directory ```directory```.
-  - ```file.m```: run unit tests in file ```file.m```.
-  - ```-logfile logfile.txt```: store the output in file ```logfile.txt```.
+- `moxunit_runtests`, by default, gives non-verbose output and runs all tests in the current directory. This can be changed using the following arguments:
+  - `-verbose`: show verbose output.
+  - `directory`: run unit tests in directory `directory`.
+  - `file.m`: run unit tests in file `file.m`.
+  - `-logfile logfile.txt`: store the output in file `logfile.txt`.
 
 - To test MOxUnit itself using a shell, run:
     ```
@@ -73,19 +73,19 @@ function test_suite=my_test_of_abs
     initTestSuite;
 ```
 
-*Important*: it is crucial that the output of the main function is called ``test_suite``.
+*Important*: it is crucial that the output of the main function is called `test_suite`.
 
-Then, define subfunctions whose name start with ``test_`` or end with ``_test``. These functions can use the following ``assert*`` functions:
-- ```assertTrue(a)```: assert that ```a``` is true.
-- ```assertFalse(a)```: assert that ```a``` is false.
-- ```assertEqual(a,b)```: assert that ```a``` and ```b``` are equal.
-- ```assertElementsAlmostEqual(a,b)```: assert that the floating point arrays ```a``` and ```b``` have the same size, and that corresponding elements are equal within some numeric tolerance.
-- ```assertVectorsAlmostEqual(a,b)```: assert that floating point vectors ```a``` and ```b``` have the same size, and are equal within some numeric tolerance based on their vector norm.
-- ```assertExceptionThrown(f,id)```: assert that calling ``f()`` throws an exception with identifier ``id``. (To deal with cases where Matlab and GNU Octave throw errors with different identifiers, use ```moxunit_util_platform_is_octave``)`.
+Then, define subfunctions whose name start with `test_` or end with `_test`. These functions can use the following `assert*` functions:
+- `assertTrue(a)`: assert that `a` is true.
+- `assertFalse(a)`: assert that `a` is false.
+- `assertEqual(a,b)`: assert that `a` and `b` are equal.
+- `assertElementsAlmostEqual(a,b)`: assert that the floating point arrays `a` and `b` have the same size, and that corresponding elements are equal within some numeric tolerance.
+- `assertVectorsAlmostEqual(a,b)`: assert that floating point vectors `a` and `b` have the same size, and are equal within some numeric tolerance based on their vector norm.
+- `assertExceptionThrown(f,id)`: assert that calling `f()` throws an exception with identifier `id`. (To deal with cases where Matlab and GNU Octave throw errors with different identifiers, use `moxunit_util_platform_is_octave`).
 
-As a special case, ```moxunit_throw_test_skipped_exception('reason')``` throws an exception that is caught when running the test; ``moxunit_run_tests`` will report that the test is skipped for reason ```reason```.
+As a special case, `moxunit_throw_test_skipped_exception('reason')` throws an exception that is caught when running the test; `moxunit_run_tests` will report that the test is skipped for reason `reason`.
 
-For example, the following function defines three unit tests that tests some possible inputs from the builtin ``abs`` function::
+For example, the following function defines three unit tests that tests some possible inputs from the builtin `abs` function::
 ```
 function test_suite=my_test_of_abs
     initTestSuite
@@ -110,21 +110,21 @@ function test_abs_exceptions
     end
 ```
 
-Examples of unit tests are in MOxUnit's ``tests`` directory, which test some of MOxUnit's functions itself.
+Examples of unit tests are in MOxUnit's `tests` directory, which test some of MOxUnit's functions itself.
 
 ### Compatibility notes
-- Because GNU Octave 3.8 does not support ``classdef``` syntax, 'old-style' object-oriented syntax is used for the class definitions. For similar reasons, MOxUnit uses the ``lasterror`` function, even though its use in Matlab is discouraged.
+- Because GNU Octave 3.8 does not support `classdef` syntax, 'old-style' object-oriented syntax is used for the class definitions. For similar reasons, MOxUnit uses the `lasterror` function, even though its use in Matlab is discouraged.
 
 
 ### Acknowledgements
 - The object-oriented class structure was inspired by the [Python unit test] framework.
-- The ``assert*`` function signatures are aimed to be compatible with Steve Eddin's [Matlab xUnit test framework].
+- The `assert*` function signatures are aimed to be compatible with Steve Eddin's [Matlab xUnit test framework].
 
 
 ### Limitations
 Currently MOxUnit does not support:
-- Documentation tests (these would require ``evalc``, which is not available on ``GNU Octave`` as of January 2014).
-- Support for setup and teardown functions in ``TestCase`` classes.
+- Documentation tests (these would require `evalc`, which is not available on `GNU Octave` as of January 2014).
+- Support for setup and teardown functions in `TestCase` classes.
 
 
 ### Contact
@@ -164,6 +164,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [MOxUnit]: github.com/MOxUnit/MOxUnit
 [Python unit test]: https://docs.python.org/2.6/library/unittest.html
 [Travis-ci]: https://travis-ci.org
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 - Using the shell (requires a Unix-like operating system such as GNU/Linux or Apple OSX):
 
     ```
-       git clone https://github.com/MOxUnit/MOxUnit.git
-       cd MOxUnit
-       make install
+    git clone https://github.com/MOxUnit/MOxUnit.git
+    cd MOxUnit
+    make install
     ```
     This will add the MOxUnit directory to the Matlab and/or GNU Octave searchpath. If both Matlab and GNU Octave are available on your machine, it will install MOxUnit for both.
 
@@ -29,9 +29,9 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
     + On the Matlab or GNU Octave prompt, ```cd``` to the ``MOxUnit`` root directory, then run:
     
         ```
-          cd MOxUnit      % cd to MOxUnit subdirectory
-          addpath(pwd())  % add the current directory to the Matlab/GNU Octave path
-          savepath        % save the path
+        cd MOxUnit      % cd to MOxUnit subdirectory
+        addpath(pwd())  % add the current directory to the Matlab/GNU Octave path
+        savepath        % save the path
         ```
 
 ### Running MOxUnit tests
@@ -59,7 +59,7 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 
 - To test MOxUnit itself using a shell, run:
     ```
-        make test
+    make test
     ```
 
 ### Use with travis-ci
@@ -69,8 +69,8 @@ MOxUnit uses the [Travis-ci] service for continuous integration testing. This is
 
 To define unit tests, write a function with the following header:
 ```
-    function test_suite=my_test_of_abs
-        initTestSuite;
+function test_suite=my_test_of_abs
+    initTestSuite;
 ```
 
 *Important*: it is crucial that the output of the main function is called ``test_suite``.
@@ -87,27 +87,27 @@ As a special case, ```moxunit_throw_test_skipped_exception('reason')``` throws a
 
 For example, the following function defines three unit tests that tests some possible inputs from the builtin ``abs`` function::
 ```
-    function test_suite=my_test_of_abs
-        initTestSuite
+function test_suite=my_test_of_abs
+    initTestSuite
 
-    function test_abs_scalar
-        assertTrue(abs(-1)==1)
-        assertEqual(abs(-NaN),NaN);
-        assertEqual(abs(-Inf),Inf);
-        assertEqual(abs(0),0)
-        assertElementsAlmostEqual(abs(-1e-13),0)
+function test_abs_scalar
+    assertTrue(abs(-1)==1)
+    assertEqual(abs(-NaN),NaN);
+    assertEqual(abs(-Inf),Inf);
+    assertEqual(abs(0),0)
+    assertElementsAlmostEqual(abs(-1e-13),0)
 
-    function test_abs_vector
-        assertEqual(abs([-1 1 -3]),[1 1 3]);
+function test_abs_vector
+    assertEqual(abs([-1 1 -3]),[1 1 3]);
 
-    function test_abs_exceptions
-        % GNU Octave and Matlab use different error identifiers
-        if moxunit_util_platform_is_octave()
-            assertExceptionThrown(@()abs(struct),'');
-        else
-            assertExceptionThrown(@()abs(struct),...
-                                 'MATLAB:UndefinedFunction');
-        end
+function test_abs_exceptions
+    % GNU Octave and Matlab use different error identifiers
+    if moxunit_util_platform_is_octave()
+        assertExceptionThrown(@()abs(struct),'');
+    else
+        assertExceptionThrown(@()abs(struct),...
+                             'MATLAB:UndefinedFunction');
+    end
 ```
 
 Examples of unit tests are in MOxUnit's ``tests`` directory, which test some of MOxUnit's functions itself.
@@ -133,28 +133,28 @@ Nikolaas N. Oosterhof, nikolaas dot oosterhof at unitn dot it
 
 ### License
 
-    (The MIT License)
+(The MIT License)
 
-    Copyright (c) 2015 Nikolaas N. Oosterhof
+Copyright (c) 2015 Nikolaas N. Oosterhof
 
-    Permission is hereby granted, free of charge, to any person obtaining
-    a copy of this software and associated documentation files (the
-    "Software"), to deal in the Software without restriction,
-    including without limitation the rights to use, copy, modify, merge,
-    publish, distribute, sublicense, and/or sell copies of the Software,
-    and to permit persons to whom the Software is furnished to do so,
-    subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 


### PR DESCRIPTION
I've tidied up the README with the following changes:
- Remove superfluous indentation to entire code blocks
- Syntax highlighting for code blocks
- Fix inline code overflow fault
- Swap to single backticks for inline code