### PR TITLE
Resolve Travis issue with apt-get update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 before_install:
     # to prevent IPv6 being used for APT
     - sudo bash -c "echo 'Acquire::ForceIPv4 \"true\";' > /etc/apt/apt.conf.d/99force-ipv4"
+    - travis_retry sudo apt-get -y -qq update
     - travis_retry sudo apt-get install -y -qq software-properties-common python-software-properties
     - travis_retry sudo apt-add-repository -y ppa:octave/stable
     - travis_retry sudo apt-get -y -qq update


### PR DESCRIPTION
Travis has move their built environment to use GCE instead of
OpenVZ.
https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future

The change in environment means the initial apt-cache does not
include `software-properties-common`, so the build started failing.

The fix is to do an `apt-get update` before installing
`software-properties-common`, then another `apt-get update` after
adding the octave repository `ppa:octave/stable`.