### PR TITLE
Improve output of elem2str utility

### DIFF
--- a/MOxUnit/moxunit_util_elem2str.m
+++ b/MOxUnit/moxunit_util_elem2str.m
@@ -18,20 +18,54 @@ function elem_str=moxunit_util_elem2str(elem, max_chars)
 %     to capture the output from disp in a variable; hence only the class
 %     of the first input is shown
 %
-% NNO Jan 2014
+% NNO, SCL 2014-2015
 
     if nargin<2
         max_chars=100;
     end
 
-    if moxunit_util_platform_is_octave()
-        elem_str=sprintf('<%s>\n',class(elem));
-    else
-        % Octave does not support evalc
+    if ischar(elem)
+        % Strings are trivally supported by leaving them as-is
+        % We just encapsulate in quotation marks to make it clear they
+        % are a string.
+        elem_str=['''' elem ''''];
+
+    elseif isnumeric(elem) && numel(elem) < max_chars
+        % If the element is numeric, we can use mat2str
+        elem_str=mat2str(elem);
+
+    elseif exist('evalc', 'builtin')
+        % If we have `evalc`, we can just trust the `display` function
+        % provided by the environment to format the string correctly
+        % and capture it with `evalc`.
         elem_str=evalc('disp(elem)');
 
         % remove trailing newlines
         elem_str=elem_str(1:(end-2));
+
+        if iscell(elem)
+            % Encapsulate output in curly braces if it is a cell.
+            % These are not included by disp.
+            elem_str = ['{ ' strtrim(elem_str) ' }'];
+        end
+
+    else
+        % Octave does not support evalc, so we need a work around.
+        % As a fall back, we just show the class of the element
+        % with the size, if we can get it.
+        try
+            siz = arrayfun(@num2str, size(elem), 'UniformOutput', false);
+            sizstr = strjoin(siz, 'x');
+            sizstr = [sizstr ' '];
+        catch
+            sizstr = '';
+        end
+        elem_str = sprintf('%s%s\n', sizstr, class(elem));
+        % NB: we can't return '<class CLASSNAME>' because the < >
+        % characters will wreck havok with the XML output and
+        % escaping them causes problems when outputting them in
+        % MATLAB/Octave.
+
     end
 
     if numel(elem_str)>max_chars

--- a/MOxUnit/moxunit_util_elem2str.m
+++ b/MOxUnit/moxunit_util_elem2str.m
@@ -43,12 +43,6 @@ function elem_str=moxunit_util_elem2str(elem, max_chars)
         % remove trailing newlines
         elem_str=elem_str(1:(end-2));
 
-        if iscell(elem)
-            % Encapsulate output in curly braces if it is a cell.
-            % These are not included by disp.
-            elem_str = ['{ ' strtrim(elem_str) ' }'];
-        end
-
     else
         % Octave does not support evalc, so we need a work around.
         % As a fall back, we just show the class of the element


### PR DESCRIPTION
Add proper support for some classes on Octave:
- string: Show the string encapsulated in quotation marks
- small numerics: use `mat2str` on the element

Since these outputs for string and numeric elements are more
informative than the output from `disp()` (it is useful to
indicate the class of these elements), these settings superceed
the `evalc(disp(elem))` method.

`evalc(disp(elem))` is still used on MATLAB for all other classes
(including cells).

On Octave, the fallback is still to indicate just the class of the
element, but now to also indicate the size if it is available.