### PR TITLE
DOC: Fix README.md to have correct junit_xml_file flag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
   - `file.m`: run unit tests in file `file.m`.
   - `-recursive`: add files from directories recursively.
   - `-logfile logfile.txt`: store the output in file `logfile.txt`.
-  - `-junit_xml xmlfile`: store JUnit-like XML output in file `xmlfile`.
+  - `-junit_xml_file xmlfile`: store JUnit-like XML output in file `xmlfile`.
 
 - To test MOxUnit itself using a shell, run:
     ```


### PR DESCRIPTION
The API had been updated, but the documentation had not.

(I was briefly very confused.)