### PR TITLE
ENH: Update bad moxunit_runtests parameter error message

### DIFF
--- a/MOxUnit/moxunit_runtests.m
+++ b/MOxUnit/moxunit_runtests.m
@@ -260,7 +260,7 @@ function params=get_params(varargin)
                     filenames{k}=arg;
                 else
                     error('moxunit:illegalParameter',...
-                    'File not found: %s', arg);
+                    'Parameter not recognised or file missing: %s', arg);
                 end
         end
     end


### PR DESCRIPTION
Rather than just saying "File not found", say the parameter was
not recognised or the file is missing. This is better because
the user could also have mistyped a flag parameter instead of
specifying a file to test which is absent.

Since several arguments refer to the generation of XML or HTML
output files, simply stating "File not found" when this argument
is mistyped can lead to confusion.