### PR TITLE
Syntactic sugar that simplifies running individual tests

### DIFF
--- a/MOxUnit/initTestSuite.m
+++ b/MOxUnit/initTestSuite.m
@@ -65,3 +65,10 @@
             end
         end
     end
+
+    % If the user didn't request an output, immediately execute the test and
+    % display its result
+    if ~nargout
+        disp(run(test_suite));
+        clear test_suite;
+    end


### PR DESCRIPTION
This change causes functions that generate test suites via initTestSuite, but
do not request the return object, to immediately execute the test rather than
assigning the object to ans.  The benefit of this is that test_<myFun> now
executes the test and shows the results.