### PR TITLE
Relaxed API for assertExceptionThrown

### DIFF
--- a/MOxUnit/assertExceptionThrown.m
+++ b/MOxUnit/assertExceptionThrown.m
@@ -1,7 +1,7 @@
 function assertExceptionThrown(func, expected_id, message)
 % assert that an exception is thrown
 %
-% assertExceptionThrown(func,expected_id[,msg])
+% assertExceptionThrown(func,[expected_id[,msg]])
 %
 % Inputs:
 %   func            function handle that should take no inputs and should
@@ -19,7 +19,13 @@ function assertExceptionThrown(func, expected_id, message)
 %
 % Raises:
 %
-    exception_was_raised=false;
+
+    % Default Values
+    exception_was_raised = false;
+    expected_id_passed = nargin>1;
+    
+    
+    % Check func for an exception and capture it
     if moxunit_util_platform_is_octave()
         try
             func();
@@ -36,15 +42,21 @@ function assertExceptionThrown(func, expected_id, message)
         end
     end
 
+    % Check for that exception meeting an id requirement
     if ~exception_was_raised
-        whatswrong=sprintf('expected exception ''%s'' was not raised',...
-                                expected_id);
-        error_id='assertExceptionThrown:noException';
-    elseif ~isequal(expected_id, found_id)
-        whatswrong=sprintf(['exception ''%s'' was raised, '...
-                                'expected ''%s'''],...
-                                found_id, expected_id);
-        error_id='assertExceptionThrown:wrongException';
+        error_id = 'assertExceptionThrown:noException';
+        if expected_id_passed
+            whatswrong = sprintf('expected exception ''%s'' was not raised',...
+                expected_id);
+        else
+            whatswrong = 'exception was not raised';
+        end
+    
+    elseif expected_id_passed && ~isequal(expected_id, found_id)
+        whatswrong = sprintf(...
+            'exception ''%s'' was raised, expected ''%s''',...
+            found_id, expected_id);
+        error_id = 'assertExceptionThrown:wrongException';
     else
         return;
     end

--- a/MOxUnit/assertExceptionThrown.m
+++ b/MOxUnit/assertExceptionThrown.m
@@ -1,7 +1,7 @@
 function assertExceptionThrown(func, expected_id, message)
 % assert that an exception is thrown
 %
-% assertExceptionThrown(func,[expected_id[,msg]])
+% assertExceptionThrown(func,[expected_id],[msg])
 %
 % Inputs:
 %   func            function handle that should take no inputs and should
@@ -15,10 +15,6 @@ function assertExceptionThrown(func, expected_id, message)
 %   'moxunit:wrongExceptionRaised'  func() does raise an exception but with
 %                                       an identifier different from
 %                                       expected_id
-%
-%
-% Raises:
-%
 
     % Default Values
     exception_was_raised = false;
@@ -44,7 +40,7 @@ function assertExceptionThrown(func, expected_id, message)
 
     % Check for that exception meeting an id requirement
     if ~exception_was_raised
-        error_id = 'assertExceptionThrown:noException';
+        error_id = 'moxunit:exceptionNotRaised';
         if expected_id_passed
             whatswrong = sprintf('expected exception ''%s'' was not raised',...
                 expected_id);
@@ -56,7 +52,7 @@ function assertExceptionThrown(func, expected_id, message)
         whatswrong = sprintf(...
             'exception ''%s'' was raised, expected ''%s''',...
             found_id, expected_id);
-        error_id = 'assertExceptionThrown:wrongException';
+        error_id = 'moxunit:wrongExceptionRaised';
     else
         return;
     end

--- a/MOxUnit/assertExceptionThrown.m
+++ b/MOxUnit/assertExceptionThrown.m
@@ -1,71 +1,120 @@
-function assertExceptionThrown(func, expected_id, message)
-% assert that an exception is thrown
+% assertExceptionThrown - Assert that an exception is thrown
+%{ 
+%-------------------------------------------------------------------------------
+% SYNTAX:
+%   assertExceptionThrown(func, <expectedID>, <message>)
 %
-% assertExceptionThrown(func,[expected_id],[msg])
+% PURPOSE:
+%   This function allows one to test for exceptions being thrown, and
+%   optionally, pass a custome message in response to a failure.
 %
-% Inputs:
-%   func            function handle that should take no inputs and should
-%                   raise an exception
-%   expected_id     the idenitifier of the exception that func should
-%                   raise
-%   msg             optional custom message
+%   e.g.
+%   % Assert that sin will throw when its argument is a struct
+%   >> assertExceptionThrown( @()sin( struct([]) ) )
 %
-% Throws:
-%   'moxunit:exceptionNotRaised'    func() does not raise an exception
-%   'moxunit:wrongExceptionRaised'  func() does raise an exception but with
-%                                       an identifier different from
-%                                       expected_id
+%   % Assert that sin throws AND that the ID is 'MATLAB:UndefinedFunction'
+%   >> assertExceptionThrown( @()sin( struct([]) ), 'MATLAB:UndefinedFunction')
+%  
+% INPUT:
+%   func        - Function handle that is expected to throw, with the prototype
+%                   [varargout{:}] = func()
+%   expectedID  - Idenitifier of the expected exception.  If expectedID is
+%                 empty, then any exception (identifier) is allowed.  When 
+%                 exactly two inputs are passed an ambiguity arises between
+%                 expectedID and message because these inputs share a common
+%                 type.  By default, we resolve this ambiguity using
+%                 moxunit_util_is_message_identifier().  If any exception is
+%                 permitted, we recommend explicitly defining expectedID to be
+%                 empty.
+%                   Default: ''
+%   message     - Custom message to be included when func fails to throw
+%   
+% THROWS:
+%   'moxunit:exceptionNotRaised'    - func() does not raise an exception but was
+%                                     expected to do so.
+%   'moxunit:wrongExceptionRaised'  - func() does raise an exception but with
+%                                     an identifier different from expected_id
+%
+% ASSUMPTIONS: 
+%   All input variables are of the correct type, valid (if applicable), and 
+%   given in the correct order. 
+%
+% See also moxunit_util_is_message_identifier
+%-------------------------------------------------------------------------------
+%}
+function assertExceptionThrown(func, expectedID, message)
 
-    % Default Values
-    exception_was_raised = false;
-    expected_id_passed = nargin>1;
-    
-    
-    % Check func for an exception and capture it
-    if moxunit_util_platform_is_octave()
-        try
-            func();
-        catch
-            exception_was_raised=true;
-            [unused,found_id]=lasterr();
-        end
-    else
-        try
-            func();
-        catch mexception;
-            exception_was_raised=true;
-            found_id=mexception.identifier;
-        end
-    end
-
-    % Check for that exception meeting an id requirement
-    if ~exception_was_raised
-        error_id = 'moxunit:exceptionNotRaised';
-        if expected_id_passed
-            whatswrong = sprintf('expected exception ''%s'' was not raised',...
-                expected_id);
+% Parse Inputs
+switch nargin
+    case 1
+        expectedID = '';
+        message = '';
+        
+    case 2
+        if moxunit_util_is_message_identifier(expectedID)
+            message = '';
         else
-            whatswrong = 'exception was not raised';
+            message = expectedID;
+            expectedID = '';
         end
+        
+    case 3
+        % Do nothing
+        
+    otherwise
+        error('assertExceptionThrown:unexpectedInput',...
+            'Unexpected number of inputs');
+end
+
+
+% Check func for an exception and capture it
+funcException = false;
+if moxunit_util_platform_is_octave()
+    try
+        func();
+    catch
+        funcException = true;
+        [~,foundID] = lasterr();
+    end
+else
+    try
+        func();
+    catch mexception
+        funcException=true;
+        foundID=mexception.identifier;
+    end
+end
+
+% Check for that exception meeting an id requirement
+if ~funcException
+    error_id = 'moxunit:exceptionNotRaised';
+    if isempty(expectedID)
+        whatswrong = 'exception was not raised';
+    else
+        whatswrong = sprintf('expected exception ''%s'' was not raised',...
+            expectedID);
+    end
     
-    elseif expected_id_passed && ~isequal(expected_id, found_id)
-        whatswrong = sprintf(...
-            'exception ''%s'' was raised, expected ''%s''',...
-            found_id, expected_id);
-        error_id = 'moxunit:wrongExceptionRaised';
-    else
-        return;
-    end
+elseif ~isempty(expectedID) && ~isequal(expectedID, foundID)
+    whatswrong = sprintf(...
+        'exception ''%s'' was raised, expected ''%s''',...
+        foundID, expectedID);
+    error_id = 'moxunit:wrongExceptionRaised';
+else
+    return;
+end
 
-    if nargin<3
-        message='';
-    end
+if nargin<3
+    message='';
+end
 
-    full_message=moxunit_util_input2str(message,whatswrong);
+full_message=moxunit_util_input2str(message,whatswrong);
 
-    if moxunit_util_platform_is_octave()
-        error(error_id,full_message);
-    else
-        throwAsCaller(MException(error_id, full_message));
-    end
+if moxunit_util_platform_is_octave()
+    error(error_id,full_message);
+else
+    throwAsCaller(MException(error_id, full_message));
+end
+
+end
 

--- a/MOxUnit/util/moxunit_util_is_message_identifier.m
+++ b/MOxUnit/util/moxunit_util_is_message_identifier.m
@@ -1,0 +1,30 @@
+function tf=moxunit_util_is_message_identifier(id)
+% returns whether the input string is a message identifier
+%
+% tf=moxunit_util_is_message_identifier(string)
+%
+% Input:
+%   id              input string
+%
+% Output
+%   tf              true if the input string is a message identifier. A
+%                   message identifier is a string with the following
+%                   properties:
+%                   - contains only alphanumeric characters, and/or the
+%                     underscore character ('_') and colon (':')
+%                   - it contains at least one colon
+%                   - the first character is an alphabetic character
+%                   - every colon is immediately followed by an alphabetic
+%                     character
+
+    if ~ischar(id)
+        error('illegal input: first argument must be char');
+    end
+
+    alpha_pat='[a-zA-Z]';
+    word_pat='\w';
+
+    id_pat=sprintf('(%s(%s*))',alpha_pat,word_pat);
+    pat=sprintf('^%s(:%s)+$',id_pat,id_pat);
+
+    tf=~isempty(regexp(id, pat, 'once'));

--- a/MOxUnit/util/moxunit_util_is_message_identifier.m
+++ b/MOxUnit/util/moxunit_util_is_message_identifier.m
@@ -1,7 +1,7 @@
-function tf=moxunit_util_is_message_identifier(id)
+function tf = moxunit_util_is_message_identifier(id)
 % returns whether the input string is a message identifier
 %
-% tf=moxunit_util_is_message_identifier(string)
+% tf = moxunit_util_is_message_identifier(string)
 %
 % Input:
 %   id              input string
@@ -21,10 +21,10 @@ function tf=moxunit_util_is_message_identifier(id)
         error('illegal input: first argument must be char');
     end
 
-    alpha_pat='[a-zA-Z]';
-    word_pat='\w';
+    alpha_pat = '[a-zA-Z]';
+    word_pat = '\w';
 
-    id_pat=sprintf('(%s(%s*))',alpha_pat,word_pat);
-    pat=sprintf('^%s(:%s)+$',id_pat,id_pat);
+    id_pat = sprintf('(%s(%s*))',alpha_pat,word_pat);
+    pat = sprintf('^%s(:%s)+$',id_pat,id_pat);
 
-    tf=~isempty(regexp(id, pat, 'once'));
+    tf = ~isempty(regexp(id, pat, 'once'));

--- a/tests/test_assert_exception_thrown.m
+++ b/tests/test_assert_exception_thrown.m
@@ -10,31 +10,48 @@ function test_assert_exception_thrown_passes
         'moxunit:error','message');
     assertExceptionThrown(@()error('moxunit:error','msg'),...
         'message');
+    assertExceptionThrown(@()error('moxunit:error','msg'),...
+        '*','message');                                         % Same as above
+    assertExceptionThrown(@()error('Throw w/o ID'),...
+        '*','message');                                         % Same as above
+    assertExceptionThrown(@()error('moxunit:error','msg'),...
+        '*');                                                   % Any error OK
+    assertExceptionThrown(@()error('Throw w/o ID'),...
+        '*');                                                   % Same as above
+    
+    % Explicitly assert that an error is thrown without an ID
+    assertExceptionThrown(@()error('Throw w/o ID'),...
+        '');
     
 % Test cases where func throws exceptions and we need to throw as well
 function test_assert_exception_thrown_exceptions
     % Verify that when func throws but the wrong exception comes out, we respond
     % with the correct exception (assertExceptionThrown:wrongException)
-    try
-        assertExceptionThrown(@()error('moxunit:error','msg'),...
-                                    'moxunit:failed','msg');
-        did_throw = false;
-    catch
-        caught_error = lasterror();
-        did_throw = true;
-    end
-
-    if did_throw
-        if ~strcmp(caught_error.identifier,'moxunit:wrongExceptionRaised')
-            error('moxunit:wrongExceptionRaised',...
-                    ['Expected exception ''moxunit:wrongExceptionRaised'', ',...
-                     'but got ''%s'''], caught_error.identifier);
-        end
-    else
-        error('moxunit:exceptionNotRaised',...
-                'Expected exception, ''moxunit:error'', not thrown');
-    end
+    exceptionIDArray = {'moxunit:failed',''};
     
+    for exceptionID = exceptionIDArray
+        exceptionID = exceptionID{1};       % Unwrap
+        try
+            assertExceptionThrown(@()error('moxunit:error','msg'),...
+                exceptionID,'msg');
+            did_throw = false;
+        catch
+            caught_error = lasterror();
+            did_throw = true;
+        end
+        
+        if did_throw
+            if ~strcmp(caught_error.identifier,'moxunit:wrongExceptionRaised')
+                error('moxunit:wrongExceptionRaised',...
+                    ['Expected exception ''moxunit:wrongExceptionRaised'', ',...
+                    'but got ''%s'''], caught_error.identifier);
+            end
+        else
+            error('moxunit:exceptionNotRaised',...
+                'Expected exception, ''moxunit:error'', not thrown');
+        end
+        
+    end
     
 % Test cases where func does not throw but was expected to do so
 function test_assert_exception_thrown_exceptions_not_thrown
@@ -45,6 +62,7 @@ function test_assert_exception_thrown_exceptions_not_thrown
         {},...                  % No arguments
         {'moxunit:failed'},...  % Identifier only
         {'Some message'},...    % Message only
+        {'*','message'},...     % Same as above but explicit
         {'a:b','msg'}};         % Identifier and message
     
     for argCell = argArray

--- a/tests/test_assert_exception_thrown.m
+++ b/tests/test_assert_exception_thrown.m
@@ -18,10 +18,10 @@ function test_assert_exception_thrown_exceptions
     try
         assertExceptionThrown(@()error('moxunit:error','msg'),...
                                     'moxunit:failed','msg');
-        did_throw=false;
+        did_throw = false;
     catch
-        caught_error=lasterror();
-        did_throw=true;
+        caught_error = lasterror();
+        did_throw = true;
     end
 
     if did_throw
@@ -39,23 +39,38 @@ function test_assert_exception_thrown_exceptions
 % Test cases where func does not throw but was expected to do so
 function test_assert_exception_thrown_exceptions_not_thrown
 
-    try
-        assertExceptionThrown(@do_nothing,'moxunit:failed','msg');
-        did_throw=false;
-    catch
-        caught_error=lasterror();
-        did_throw=true;
-    end
-
-    if did_throw
-        if ~strcmp(caught_error.identifier,'moxunit:exceptionNotRaised')
-            error('moxunit:exceptionNotRaised',...
-                   ['Expected exception ''moxunit:exceptionNotRaised'' ',...
-                    'but got ''%s'''], caught_error.identifier);
+    % For all combination of optional arguments we expect the same behavior.
+    % We will loop, testing all combinations here
+    argArray = {...
+        {},...                  % No arguments
+        {'moxunit:failed'},...  % Identifier only
+        {'Some message'},...    % Message only
+        {'a:b','msg'}};         % Identifier and message
+    
+    for argCell = argArray
+        % Strip the wrapping cell array
+        argCell = argCell{1};
+        
+        % Run the test
+        try
+            assertExceptionThrown(@do_nothing,argCell{:});
+            did_throw=false;
+        catch
+            caught_error=lasterror();
+            did_throw=true;
         end
-    else
-        error('moxunit:exceptionNotRaised',...
+        
+        if did_throw
+            if ~strcmp(caught_error.identifier,'moxunit:exceptionNotRaised')
+                error('moxunit:exceptionNotRaised',...
+                    ['Expected exception ''moxunit:exceptionNotRaised'' ',...
+                    'but got ''%s'''], caught_error.identifier);
+            end
+        else
+            error('moxunit:exceptionNotRaised',...
                 'Expected exception, ''moxunit:error'', not thrown');
+        end
+        
     end
     
 

--- a/tests/test_assert_exception_thrown.m
+++ b/tests/test_assert_exception_thrown.m
@@ -8,6 +8,8 @@ function test_assert_exception_thrown_passes
         'moxunit:error');
     assertExceptionThrown(@()error('moxunit:error','msg'),...
         'moxunit:error','message');
+    assertExceptionThrown(@()error('moxunit:error','msg'),...
+        'message');
     
 % Test cases where func throws exceptions and we need to throw as well
 function test_assert_exception_thrown_exceptions
@@ -23,14 +25,14 @@ function test_assert_exception_thrown_exceptions
     end
 
     if did_throw
-        if ~strcmp(caught_error.identifier,'assertExceptionThrown:wrongException')
-            error('assertExceptionThrown:wrongException',...
-                    'Expected exception moxunit: error but got ''%s''',...
-                        caught_error.identifier);
+        if ~strcmp(caught_error.identifier,'moxunit:wrongExceptionRaised')
+            error('moxunit:wrongExceptionRaised',...
+                    ['Expected exception ''moxunit:wrongExceptionRaised'', ',...
+                     'but got ''%s'''], caught_error.identifier);
         end
     else
-        error('assertExceptionThrown:noException',...
-                'Expected exception ''moxunit:error'' but not thrown');
+        error('moxunit:exceptionNotRaised',...
+                'Expected exception, ''moxunit:error'', not thrown');
     end
     
     
@@ -46,14 +48,14 @@ function test_assert_exception_thrown_exceptions_not_thrown
     end
 
     if did_throw
-        if ~strcmp(caught_error.identifier,'assertExceptionThrown:noException')
-            error('assertExceptionThrown:wrongException',...
-                    'Expected exception ''moxunit:error'' but got %s',...
-                        caught_error.identifier);
+        if ~strcmp(caught_error.identifier,'moxunit:exceptionNotRaised')
+            error('moxunit:exceptionNotRaised',...
+                   ['Expected exception ''moxunit:exceptionNotRaised'' ',...
+                    'but got ''%s'''], caught_error.identifier);
         end
     else
-        error('assertExceptionThrown:noException',...
-                'Expected exception ''moxunit:error'' but not thrown');
+        error('moxunit:exceptionNotRaised',...
+                'Expected exception, ''moxunit:error'', not thrown');
     end
     
 

--- a/tests/test_assert_exception_thrown.m
+++ b/tests/test_assert_exception_thrown.m
@@ -1,7 +1,18 @@
 function test_suite=test_assert_exception_thrown()
     initTestSuite;
 
+% Test cases where exceptions are thrown and that is OK
+function test_assert_exception_thrown_passes
+    assertExceptionThrown(@()error('Throw w/o ID'));
+    assertExceptionThrown(@()error('moxunit:error','msg'),...
+        'moxunit:error');
+    assertExceptionThrown(@()error('moxunit:error','msg'),...
+        'moxunit:error','message');
+    
+% Test cases where func throws exceptions and we need to throw as well
 function test_assert_exception_thrown_exceptions
+    % Verify that when func throws but the wrong exception comes out, we respond
+    % with the correct exception (assertExceptionThrown:wrongException)
     try
         assertExceptionThrown(@()error('moxunit:error','msg'),...
                                     'moxunit:failed','msg');
@@ -21,7 +32,9 @@ function test_assert_exception_thrown_exceptions
         error('assertExceptionThrown:noException',...
                 'Expected exception ''moxunit:error'' but not thrown');
     end
-
+    
+    
+% Test cases where func does not throw but was expected to do so
 function test_assert_exception_thrown_exceptions_not_thrown
 
     try
@@ -42,13 +55,7 @@ function test_assert_exception_thrown_exceptions_not_thrown
         error('assertExceptionThrown:noException',...
                 'Expected exception ''moxunit:error'' but not thrown');
     end
-
-
-function test_assert_exception_thrown_passes
-    assertExceptionThrown(@()error('moxunit:error','msg'),...
-                                            'moxunit:error');
-    assertExceptionThrown(@()error('moxunit:error','msg'),...
-                                            'moxunit:error','message');
+    
 
 function do_nothing
     % do nothing

--- a/tests/test_moxunit_util_is_message_identifier.m
+++ b/tests/test_moxunit_util_is_message_identifier.m
@@ -1,0 +1,45 @@
+function test_suite=test_moxunit_util_is_message_identifier
+    initTestSuite;
+
+function test_moxunit_util_is_message_identifier_non_char
+    aet=@(varargin)assertExceptionThrown(@()...
+                    moxunit_util_is_message_identifier(varargin{:}),'');
+
+    aet(struct());                      % struct
+    aet({'id:id2'});                    % cell
+    aet(2);                             % numeric
+    aet(false);                         % boolean
+    aet(true);                          % boolean
+    aet([]);                          % boolean
+
+function test_moxunit_util_is_message_identifier_true
+    true_strs={'a:b',...
+                'a___:b___',...
+                'abc:def:ghi:jkl:mno',...
+                'a_b:c_123',...
+                };
+
+    for k=1:numel(true_strs)
+        s=true_strs{k};
+        assertTrue(moxunit_util_is_message_identifier(s),s);
+    end
+
+
+function test_test_moxunit_util_is_message_identifier_false
+    false_strs={'',...                  % empty string
+                'a',...                 % missing colon
+                'ab: cd',...            % contains space
+                sprintf('ab:c\td'),...  % contains tabs
+                '_a:b',...              % starts with underscore
+                'a:_b',...              % starts with underscore
+                '1ab:def',...           % has a number
+                ':abc:def:',...         % starts with colon
+                'abc:def:',...          % ends with colon
+                };
+
+
+    for k=1:numel(false_strs)
+        s=false_strs{k};
+
+        assertFalse(moxunit_util_is_message_identifier(s),s);
+    end


### PR DESCRIPTION
**Issue**: assertExceptionThrown does not support functions that throw without an exception ID.

**Proposed Solution**: Relax the API of assertExceptionThrown.m so that when this function is called without an expected exception ID, any exception is sufficient.

**Usage Example**:

`assertExceptionThrown(@()error('Without ID'))`

**Tested**:

- [x] Matlab 2015b
- [x] Octave 4.0.2
