### PR TITLE
vertical cat of two horizontal vectors

### DIFF
--- a/MOxUnit/moxunit_runtests.m
+++ b/MOxUnit/moxunit_runtests.m
@@ -176,7 +176,7 @@ function test_report=run_all_tests(suite, test_report, params)
             elseif iscell(value)
                 n_values=numel(value);
                 param_elem_matrix=[repmat({key_arg},1,n_values);...
-                                           value(:)];
+                                           value(:)'];
                 param_elem=param_elem_matrix(:)';
             else
                 error('moxunit:illegalParameterValue',...


### PR DESCRIPTION
value(:) is vertical, so it cannot be concatenated below repmat({key_arg},1,n_values)