### PR TITLE
[DNM] Demonstrate Github CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "unit-tests"
+  unit-tests:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Use A Github Action to perform tests
+    - name: run unit tests and documentation tests, generate coverage report
+      uses: joergbrech/moxunit-action@v1.1
+      with:
+        tests: tests
+        src: MOxUnit
+        with_coverage: true
+        doc_tests: true
+        cover_xml_file: coverage.xml
+
+    # Store the coverage report as an artifact
+    - name: Store Coverage report as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: coverage_xml_file
+        path: coverage.xml
+    
+    ## Use a Github Action to publish coverage reports
+    #- name: Publish coverage report to codecov.io
+    #  uses: codecov/codecov-action@v1
+    #    with:
+    #    file: ./coverage.xml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,8 +37,8 @@ jobs:
         name: coverage_xml_file
         path: coverage.xml
     
-    ## Use a Github Action to publish coverage reports
-    #- name: Publish coverage report to codecov.io
-    #  uses: codecov/codecov-action@v1
-    #    with:
-    #    file: ./coverage.xml
+    # Use a Github Action to publish coverage reports
+    - name: Publish coverage report to codecov.io
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MOxUnit [![Build Status](https://travis-ci.org/nno/MOxUnit.svg?branch=master)](https://travis-ci.org/MOxUnit/MOxUnit) ![Test](https://github.com/MOxUnit/MOxUnit/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/MOxUnit/MOxUnit/badge.svg?branch=master)](https://coveralls.io/github/MOxUnit/MOxUnit?branch=master)
+# MOxUnit [![Build Status](https://travis-ci.org/nno/MOxUnit.svg?branch=master)](https://travis-ci.org/MOxUnit/MOxUnit) ![Test](https://github.com/joergbrech/MOxUnit/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/MOxUnit/MOxUnit/badge.svg?branch=master)](https://coveralls.io/github/MOxUnit/MOxUnit?branch=master)
 
 MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MOxUnit [![Build Status](https://travis-ci.org/nno/MOxUnit.svg?branch=master)](https://travis-ci.org/MOxUnit/MOxUnit) [![Coverage Status](https://coveralls.io/repos/github/MOxUnit/MOxUnit/badge.svg?branch=master)](https://coveralls.io/github/MOxUnit/MOxUnit?branch=master)
+# MOxUnit [![Build Status](https://travis-ci.org/nno/MOxUnit.svg?branch=master)](https://travis-ci.org/MOxUnit/MOxUnit) ![Test](https://github.com/MOxUnit/MOxUnit/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/MOxUnit/MOxUnit/badge.svg?branch=master)](https://coveralls.io/github/MOxUnit/MOxUnit?branch=master)
 
 MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 


### PR DESCRIPTION
This adds a Github CI workflow to demonstrate how to use MOxUnit with Github CI.

- Here is a demo of the CI badge: https://github.com/joergbrech/MOxUnit/blob/master/README.md
- Since the workflow is only activated on this repo after the merge, you can check out the CI results from `joergbrech:master` here: https://github.com/joergbrech/MOxUnit/actions/runs/66312249


Fixes #61 