### PR TITLE
README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ octave-workspace
 git_log.txt
 git_summary.txt
 *.pyc
+*.asv

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# MOxUnit [![Build Status](https://travis-ci.org/nno/MOxUnit.svg?branch=master)](https://travis-ci.org/MOxUnit/MOxUnit) ![Test](https://github.com/MOxUnit/MOxUnit/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/MOxUnit/MOxUnit/badge.svg?branch=master)](https://coveralls.io/github/MOxUnit/MOxUnit?branch=master)
+# MOxUnit [![Build Status](https://travis-ci.org/nno/MOxUnit.svg?branch=master)](https://travis-ci.org/MOxUnit/MOxUnit) ![Test](https://github.com/MOxUnit/MOxUnit/workflows/CI/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/MOxUnit/MOxUnit/badge.svg?branch=master)](https://coveralls.io/github/MOxUnit/MOxUnit?branch=master) <!-- omit in toc -->
 
 MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 
-### Features
+- [Features](#features)
+- [Installation](#installation)
+- [Defining MOxUnit tests](#defining-moxunit-tests)
+- [Running MOxUnit tests](#running-moxunit-tests)
+- [Use with CI](#use-with-ci)
+  - [Octave](#octave)
+  - [Matlab](#matlab)
+- [Compatibility notes](#compatibility-notes)
+- [Limitations](#limitations)
+
+## Features
 
 - Runs on both the [Matlab] and [GNU Octave] platforms.
 - Uses object-oriented TestCase, TestSuite and TestResult classes, allowing for user-defined extensions.
@@ -13,7 +23,7 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
 - Distributed under the MIT license, a permissive free software license.
 
 
-### Installation
+## Installation
 
 - Using the shell (requires a Unix-like operating system such as GNU/Linux or Apple OSX):
 
@@ -45,46 +55,12 @@ MOxUnit is a lightweight unit test framework for Matlab and GNU Octave.
         savepath
         ```
 
-### Running MOxUnit tests
-
-- `cd` to the directory where the unit tests reside. For MOxUnit itself, the unit tests are in the directory `tests`.
-- run the tests using `moxunit_runtests`. For example, running `moxunit_runtests` from MOxUnit's `tests` directory runs tests for MOxUnit itself, and should give the following output:
-
- ```
-  ............................................................
-  .........................
-  --------------------------------------------------
-  OK (passed=85)
-  
-  ans =
-  
-       1
-  ```
-
-- `moxunit_runtests`, by default, gives non-verbose output and runs all tests in the current directory. This can be changed using the following arguments:
-  - `-verbose`: show verbose output.
-  - `directory`: run unit tests in directory `directory`.
-  - `file.m`: run unit tests in file `file.m`.
-  - `-recursive`: add files from directories recursively.
-  - `-logfile logfile.txt`: store the output in file `logfile.txt`.
-  - `-junit_xml_file xmlfile`: store JUnit-like XML output in file `xmlfile`.
-
-- To test MOxUnit itself from a terminal, run:
-
-  ```
-    make test
-  ```
-
-### Use with travis-ci and Shippable
-MOxUnit uses the [Travis-ci] service for continuous integration testing. This is achieved by setting up a [.travis.yml configuration file](.travis.yml). This file is also used by [Shippable].
-As a result, the test suite is run automatically on both [Travis-ci] and [Shippable] every time it is pushed to the github repository, or when a pull request is made. If a test fails, or if all tests pass after a test failed before, the developers are notified by email.
-
-### Defining MOxUnit tests
+## Defining MOxUnit tests
 
 To define unit tests, write a function with the following header:
 
 ```matlab
-function test_suite=my_test_of_abs
+function test_suite=test_of_abs
     try % assignment of 'localfunctions' is necessary in Matlab >= 2016
         test_functions=localfunctions();
     catch % no problem; early Matlab versions can use initTestSuite fine
@@ -92,11 +68,14 @@ function test_suite=my_test_of_abs
     initTestSuite;
 ```
 
-*Important*:
-- it is crucial that the output of the main function is a variable named `test_suite`, and that the output of `localfunctions` is assigned to a variable named `test_functions`
-- as of Matlab 2016b, Matlab scripts (such as `initTestSuite.m`) do not have access to subfunctions in a function if called from that function. Therefore it requires using localfunctions to obtain function handles to local functions. The "try-catch-end" statements are necessary for compatibility with older versions of GNU Octave, which do not provide the `localfunctions` function.
+### Important <!-- omit in toc -->
+
+- It is crucial that the output of the main function is a variable named `test_suite`, and that the output of `localfunctions` is assigned to a variable named `test_functions`.
+- As of Matlab 2016b, Matlab scripts (such as `initTestSuite.m`) do not have access to subfunctions in a function if called from that function. Therefore it requires using localfunctions to obtain function handles to local functions. The "try-catch-end" statements are necessary for compatibility with older versions of GNU Octave, which do not provide the `localfunctions` function.
+- Alas, the call to `localfunctions` **cannot** be incorporated into `initTestSuite` so the entire code snippet above has to be the header of each test file
 
 Then, define subfunctions whose name start with `test` or end with `test` (case-insensitive). These functions can use the following `assert*` functions:
+
 - `assertTrue(a)`: assert that `a` is true.
 - `assertFalse(a)`: assert that `a` is false.
 - `assertEqual(a,b)`: assert that `a` and `b` are equal.
@@ -107,8 +86,9 @@ Then, define subfunctions whose name start with `test` or end with `test` (case-
 As a special case, `moxunit_throw_test_skipped_exception('reason')` throws an exception that is caught when running the test; `moxunit_run_tests` will report that the test is skipped for reason `reason`.
 
 For example, the following function defines three unit tests that tests some possible inputs from the builtin `abs` function:
+
 ```matlab
-function test_suite=my_test_of_abs
+function test_suite=test_of_abs
     try % assignment of 'localfunctions' is necessary in Matlab >= 2016
         test_functions=localfunctions();
     catch % no problem; early Matlab versions can use initTestSuite fine
@@ -137,24 +117,119 @@ function test_abs_exceptions
 
 Examples of unit tests are in MOxUnit's `tests` directory, which test some of MOxUnit's functions itself.
 
-### Compatibility notes
+## Running MOxUnit tests
+
+- `cd` to the directory where the unit tests reside. For MOxUnit itself, the unit tests are in the directory `tests`.
+- run the tests using `moxunit_runtests`. For example, running `moxunit_runtests` from MOxUnit's `tests` directory runs tests for MOxUnit itself, and should give the following output:
+
+```matlab
+>> moxunit_runtests
+suite: 98 tests
+............................................................
+......................................
+--------------------------------------------------
+
+OK (passed=98)
+ans =
+  logical
+   1
+```
+
+- `moxunit_runtests`, by default, gives non-verbose output and runs all tests in the current directory. This can be changed using the following arguments:
+  - `-verbose`: show verbose output.
+  - `-quiet`: supress all output
+  - `directory`: run unit tests in directory `directory`.
+  - `file.m`: run unit tests in file `file.m`.
+  - `-recursive`: add files from directories recursively.
+  - `-logfile logfile.txt`: store the output in file `logfile.txt`.
+  - `-junit_xml_file xmlfile`: store JUnit-like XML output in file `xmlfile`.
+
+- To test MOxUnit itself from a terminal, run:
+
+  ```
+    make test
+  ```
+## Use with CI
+
+MOxUnit can be used with the [Travis-ci] service for continuous integration (CI) testing. This is achieved by setting up a [.travis.yml configuration file](.travis.yml). This file is also used by [Shippable]. As a result, the test suite is run automatically on both [Travis-ci] and [Shippable] every time it is pushed to the github repository, or when a pull request is made. If a test fails, or if all tests pass after a test failed before, the developers are notified by email.
+
+### Octave
+
+The easiest test to set up on Travis and/or Shippable is with [GNU Octave]. Make sure your code is Octave compatible. Note that many Matlab projects tend to use functionality not present in Octave (such as particular functions), whereasand writing code that is both Matlab- and Octave-compatible may require some additional efforts.
+
+A simple `.travis.yml` file for a project could look like that:
+
+```yaml
+language: generic
+os: linux
+      
+before_install:
+  - sudo apt-get install octave
+
+before_script:
+  - git clone https://github.com/MOxUnit/MOxUnit.git
+  - make -C MOxUnit install
+
+script:        
+  - make test
+```
+
+In this case `make test` is used to run the tests. To avoid a Makefile and run tests directly through Octave, the script has to call Octave directly to run the tests:
+
+  ```yaml
+  # ...
+  before_script:
+  - git clone https://github.com/MOxUnit/MOxUnit.git
+
+  script:
+    - octave --no-gui --eval "addpath('~/git/MOxUnit/MOxUnit');moxunit_set_path;moxunit_runtests('tests')"
+  ```
+
+Note that MOxUnit tests **itself** on travis, with [this](https://github.com/MOxUnit/MOxUnit/blob/master/.travis.yml) travis file.
+
+
+### Matlab
+
+Travis [now supports Matlab](https://docs.travis-ci.com/user/languages/matlab/ directly. You can use MOxUnit with it, but its tricky because:
+  1) Travis only supports Matlab 2020a and, presumably, higher (at the time of writing 2020a is the newest version).
+  2) Makefile installation does not work with Matlab on travis.
+  3) Nor does calling Matlab from the command line in a usuall way - with ` matlab -nodesktop -nosplash ...` . Instead it has to be called with the `-batch` flag.
+  
+  Therefore, `.travis.yml` file looks as follows:
+  ```yml
+  language: matlab
+  matlab: R2020a
+  os: linux
+
+  # Just clone MOxUnit, `dont make install` it (!)
+  before_script:
+    - git clone https://github.com/MOxUnit/MOxUnit.git
+      
+  script: 
+    - matlab -batch 'back=cd("./MOxUnit/MOxUnit/"); moxunit_set_path(); cd(back); moxunit_runtests tests -verbose; exit(double(~ans))'
+  ```
+
+  `exit(double(~ans))` ensures that the build fails if MOxUnit tests fail.
+  
+## Compatibility notes
+
 - Because GNU Octave 3.8 does not support `classdef` syntax, 'old-style' object-oriented syntax is used for the class definitions. For similar reasons, MOxUnit uses the `lasterror` function, even though its use in Matlab is discouraged.
 - Recent versions of Matlab (2016 and later) do not support tests defined just using "initTestSuite", that is without the use of `localfunctions` (see above). To ease the transition, consider using the Python script `tools/fix_mfile_test_init.py`, which can update existing .m files that do not use `localfunctions`.
 
   For example, the following command was used on a Unix-like shell to preview changes to MOxUnit's tests:
 
-  ```
+  ```bash
     find tests -iname 'test*.m' | xargs -L1 tools/fix_mfile_test_init.py
   ```
 
   and adding the `--apply` option applies these changes, meaning that found files are rewritten:
 
-  ```
+  ```bash
     find tests -iname 'test*.m' | xargs -L1 tools/fix_mfile_test_init.py --apply
   ```
 - Recent versions of Matlab define a `matlab.unittest.Test` class for unit tests. An instance `t` can be used with MOxUnit using the `MOxUnitMatlabUnitWrapperTestCase(t)`, which is a `MOxUnitTestCase` instance. Tests that are defined through
 
-    ```
+    ```matlab
     function tests=foo()
         tests=functiontests(localfunctions)
 
@@ -165,45 +240,30 @@ Examples of unit tests are in MOxUnit's `tests` directory, which test some of MO
 
   can be run using MOxUnit as well (and included in an ``MOxUnitTestSuite`` instance using its with ``addFile``) instance, with the exception that currently setup and teardown functions are currently ignored.
 
-### Acknowledgements
-- The object-oriented class structure was inspired by the [Python unit test] framework.
-- The `assert*` function signatures are aimed to be compatible with Steve Eddin's [Matlab xUnit test framework].
+## Limitations
 
-
-### Limitations
 Currently MOxUnit does not support:
 - Documentation tests require [MOdox].
 - Support for setup and teardown functions in `TestCase` classes.
 - Subclasses of MOxUnit's classes (`MOxUnitTestCase`, `MOxUnitTestSuite`, `MOxUnitTestReport`) have to be defined using "old-style" object-oriented syntax.
+- Subtests
+
+## Acknowledgements <!-- omit in toc -->
+
+- The object-oriented class structure was inspired by the [Python unit test] framework.
+- The `assert*` function signatures are aimed to be compatible with Steve Eddin's [Matlab xUnit test framework].
 
 
-### Contact
+## Contact <!-- omit in toc -->
+
 Nikolaas N. Oosterhof, n dot n dot oosterhof at googlemail dot com.
 
 
-### Contributions
+## Contributions <!-- omit in toc -->
+
 - Thanks to Scott Lowe, Thomas Feher, Joel LeBlanc, Anderson Bravalheri, Sven Baars and 'jdbancal' for contributions.
 
-
-### Frequently Asked Questions (FAQ)
-- *I would like to use unit tests with travis for a Matlab project. Can I use MOxUnit?*
-
-  Yes, as long as your code is Octave compatible, as it seems not possible to run the proprietary Matlab software on travis ( (if you found a way to do this, please let us know and we will update this entry). Also bear in mind that many Matlab projects tend to use functionality not present in Octave (such as particular functions), whereasand writing code that is both Matlab- and Octave-compatible may require some additional efforts.
-
-- *If I want to use travis for running tests, what should I put in `.travis.yml`?*
-
-  MOxUnit tests itself on travis, and this is the travis file:
-
-    https://github.com/MOxUnit/MOxUnit/blob/master/.travis.yml
-
-  It uses the Makefile to run the tests. To avoid a Makefile and run tests directly through Octave, `.travis.yml` needs a line that calls Octave to run the tests. For example:
-
-  ```
-  octave --no-gui --eval "addpath('~/git/MOxUnit/MOxUnit');moxunit_set_path;moxunit_runtests('tests')"
-  ```
-
-
-### License
+## License <!-- omit in toc -->
 
 (The MIT License)
 


### PR DESCRIPTION
Commit in response to issue #64. 

- Added info about runing matlab on Travis
- Added table of content
- Rearranged the README file a bit, so that it reads better (more in the order one actually wants to know things when setting up a project)
- Changed subsubheadings to subheadings
- Fixed a "bug" in the example test (`my_test_of_abs` doesn't run. It should be `test_of_abs`)
- Added Matlab's .asv to .gitignore