### PR TITLE
Fix resource leak in `runtests`

### DIFF
--- a/MOxUnit/moxunit_runtests.m
+++ b/MOxUnit/moxunit_runtests.m
@@ -72,7 +72,7 @@ function result=moxunit_runtests(varargin)
     params=get_params(varargin{:});
 
     if params.fid>2
-        % not standard or error output; file most be closed
+        % not standard or error output; file must be closed
         % afterwards
         cleaner=onCleanup(@()fclose(params.fid));
     end
@@ -80,7 +80,7 @@ function result=moxunit_runtests(varargin)
     suite=MOxUnitTestSuite();
 
     % build pattern for filenames by combining the test name pattern with
-    % extension.
+    % extension
     mfile_ext_pattern='.m$';
     mfile_test_filename_pattern=get_test_file_pattern(mfile_ext_pattern);
 
@@ -362,6 +362,10 @@ function params=get_params(varargin)
                 if ~isempty(dir(arg))
                     to_test_spec{k}=arg;
                 else
+                    % Close the file if it has been already open before
+                    % throwing an error. This prevents resource leak and,
+                    % eventually 'Too many files open' error.
+                    try fclose(params.fid); end %#ok<TRYNC>
                     error('moxunit:illegalParameter',...
                     'Parameter not recognised or file missing: %s', arg);
                 end


### PR DESCRIPTION
Close 'params.fid' if `get_params` throws an error. This happened in MOxUnit tests (of itself) 128 times in the `test_moxunit_runtests_basics` (half of `all_binary_combinations(8)`). This led to [windows complaining about there being too many files open by one process](https://uk.mathworks.com/matlabcentral/answers/387308-why-i-am-getting-the-error-too-many-open-files-close-files-to-prevent-matlab-instability) after running ` moxunit_runtests` a couple of times.

In principle this could be fixed by just calling `fclose('all')` at the end of tests, but I've traced it down and I think this is neater. Now calling `numel(fopen('all'))` before and after `moxunit_runtests` returns identical results (I guess so long as the tests themselves don't leak resources).