### PR TITLE
BLD: also install octave-dev, necessary for MOcov

### DIFF
--- a/.github/workflows/CI_octave.yml
+++ b/.github/workflows/CI_octave.yml
@@ -39,7 +39,7 @@ jobs:
             run: |
                 sudo apt-get -y -qq update
                 sudo apt-get -y install \
-                  octave
+                  octave octave-dev
                 make install
                 make -C MOcov install
         -   name: Octave version


### PR DESCRIPTION
This addresses failing builds, caused by failing compilation of mocov_line_covered.c in MOcov